### PR TITLE
⚡ Update English.json (correction for - set maxY)

### DIFF
--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -478,7 +478,7 @@
             "set minX": "Set left boundary to",
             "set maxX": "Set right boundary to",
             "set minY": "Set top boundary to",
-            "set maxY": "Set right boundary to",
+            "set maxY": "Set bottom boundary to",
             "get targetX": "target x",
             "get targetY": "target y",
             "get computedX": "current x",


### PR DESCRIPTION
There was a small mistake in "set maxY", if set minX maxX is Left & Right, then minY maxY should be Top & Bottom.

Only this one line was modified, so it should be fine, and no issues with it.
