### PR TITLE
Remove tween from tween list if timer was rejected :bug:

### DIFF
--- a/app/data/ct.libs/tween/injections/beforeroomstep.js
+++ b/app/data/ct.libs/tween/injections/beforeroomstep.js
@@ -9,6 +9,9 @@
             });
             tween.tweens.splice(i, 1);
             continue;
+        } else if (twoon.timer.rejected) {
+            tween.tweens.splice(i, 1);
+            continue;
         }
         let a = twoon.timer.time * 1000 / twoon.duration;
         if (a > 1) {


### PR DESCRIPTION
Closes #48 

**Changes proposed in this pull request:**
This fixes the issue where a tween gets stopped prematurely but still exists in the tween list which causes the fields passed in to continue to affect the object. Now in the beforeroomstep event a tween will be checked if it was stopped prematurely and then remove it from the list, stopping it from continuously editing the object's properties. Open to suggestions on improvements.
 
**Ping @CosmoMyzrailGorynych**
