### PR TITLE
:bug: Fix data loss during unwrap

### DIFF
--- a/src/node_requires/resources/index.ts
+++ b/src/node_requires/resources/index.ts
@@ -443,8 +443,9 @@ export const deleteFolder = (
     folder: IAssetFolder,
     unwrapTo: IAssetFolder | null | false
 ): Promise<void> => {
+    const entriesToRemove = [...folder.entries];
     if (unwrapTo || unwrapTo === null) {
-        for (const entry of folder.entries) {
+        for (const entry of entriesToRemove) {
             if (entry.type === 'folder') {
                 moveFolder(entry, unwrapTo as IAssetFolder | null);
             } else {
@@ -453,7 +454,7 @@ export const deleteFolder = (
         }
         return deleteFolder(folder, false);
     }
-    return Promise.all(folder.entries.map((entry) => {
+    return Promise.all(entriesToRemove.map((entry) => {
         if (entry.type === 'folder') {
             return deleteFolder(entry, false);
         }


### PR DESCRIPTION
I noticed that when I was unwrapping folder with several items I was getting fewer items back than were in the folder (often one less).

This appeared to be a classic case of looping through an array while deleting from it. So I fixed it:

```
for (const entry of folder.entries) {
  // deleting folder.entries
}
```

became:

```
const entriesToRemove = [...folder.entries];
for (const entry of entriesToRemove) {
  // deleting folder.entries
}
```

I was curious if `.map(...)` worked-around the issue, so I ran the following Chrome's console:

``` 
const x = [ 1, 2, 3, 4 ];
x.map(y => y % 2 === 0 ? delete x[y] : y);
// prints out [1, true, empty, true]
```

As the output was not "[1, empty, 3, empty]" I decided to extend the fix to line 456. Although realistically the asynchronous execution would probably prevent any problems in that line.

**Ping @CosmoMyzrailGorynych**
