### PR TITLE
:zap: Add asset filters to the asset browser

### DIFF
--- a/app/data/i18n/Brazilian Portuguese.json
+++ b/app/data/i18n/Brazilian Portuguese.json
@@ -31,6 +31,14 @@
         "exit": "Sair",
         "edit": "Editar",
         "filter": "Filtro:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "loading": "Carregando…",
         "name": "Nome:",
         "next": "Próximo",

--- a/app/data/i18n/Chinese Simplified.json
+++ b/app/data/i18n/Chinese Simplified.json
@@ -41,6 +41,14 @@
         "close": "关闭",
         "couldNotLoadFromClipboard": "无法从剪贴板加载数据",
         "filter": "过滤:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "pastedFromClipboard": "从剪贴板粘贴",
         "edit": "编辑",
         "nothingToShowFiller": "这里没有什么可以展示的",

--- a/app/data/i18n/Comments.json
+++ b/app/data/i18n/Comments.json
@@ -37,6 +37,14 @@
         "zoomOut": "",
         "clear": "",
         "filter": "A verb",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "A verb",
         "search": "Shown next to a search field",
         "close": "",

--- a/app/data/i18n/Debug.json
+++ b/app/data/i18n/Debug.json
@@ -37,6 +37,14 @@
         "zoomOut": "common.zoomOut",
         "clear": "common.clear",
         "filter": "common.filter",
+        "filters": {
+            "everything": "common.filters.everything",
+            "rooms": "common.filters.rooms",
+            "scripts": "common.filters.scripts",
+            "sounds": "common.filters.sounds",
+            "templates": "common.filters.templates",
+            "textures": "common.filters.textures"
+        },
         "selectDialogue": "common.selectDialogue",
         "search": "common.search",
         "close": "common.close",

--- a/app/data/i18n/Dutch.json
+++ b/app/data/i18n/Dutch.json
@@ -37,6 +37,14 @@
         "zoomOut": "Uitzoomen",
         "clear": "Wissen",
         "filter": "Filter:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "Selecteren...",
         "search": "Zoeken:",
         "close": "Sluiten",

--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -38,6 +38,14 @@
         "exit": "Exit",
         "experimentalFeature": "This is an experimental feature.",
         "filter": "Filter:",
+        "filters": {
+            "everything": "Everything",
+            "rooms": "Rooms",
+            "scripts": "Scripts and behaviors",
+            "sounds": "Sounds",
+            "templates": "Templates",
+            "textures": "Textures, UI and FX"
+        },
         "goBack": "Go back",
         "loading": "Loading…",
         "name": "Name:",

--- a/app/data/i18n/French.json
+++ b/app/data/i18n/French.json
@@ -64,6 +64,14 @@
         "zoomOut": "Zoom arrière",
         "clear": "Nettoyer",
         "filter": "Filtrer :",
+        "filters": {
+            "everything": "Tous les assets",
+            "rooms": "Salles",
+            "scripts": "Scripts et comportements",
+            "sounds": "Sons",
+            "templates": "Modèles",
+            "textures": "Textures, UI et FX"
+        },
         "selectDialogue": "Sélectionner…",
         "search": "Rechercher :",
         "close": "Fermer",

--- a/app/data/i18n/German.json
+++ b/app/data/i18n/German.json
@@ -37,6 +37,14 @@
         "zoomOut": "Verkleinern",
         "clear": "",
         "filter": "",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "",
         "search": "",
         "close": "",

--- a/app/data/i18n/Japanese.json
+++ b/app/data/i18n/Japanese.json
@@ -38,6 +38,14 @@
     "exit": "終了",
     "experimentalFeature": "これは実験的機能です。",
     "filter": "フィルター:",
+    "filters": {
+        "everything": "",
+        "rooms": "",
+        "scripts": "",
+        "sounds": "",
+        "templates": "",
+        "textures": ""
+    },
     "goBack": "戻る",
     "loading": "読み込み中・・・",
     "name": "名前:",

--- a/app/data/i18n/Polish.json
+++ b/app/data/i18n/Polish.json
@@ -37,6 +37,14 @@
         "select": "",
         "clear": "",
         "filter": "",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "",
         "search": "",
         "close": "",

--- a/app/data/i18n/Romanian.json
+++ b/app/data/i18n/Romanian.json
@@ -37,6 +37,14 @@
         "select": "",
         "clear": "",
         "filter": "",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "",
         "search": "",
         "close": "",

--- a/app/data/i18n/Russian.json
+++ b/app/data/i18n/Russian.json
@@ -43,6 +43,14 @@
         "zoomIn": "Приблизить",
         "zoomOut": "Уменьшить",
         "filter": "Отфильтровать:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "Выбрать…",
         "search": "Поиск:",
         "close": "Закрыть",

--- a/app/data/i18n/Spanish.json
+++ b/app/data/i18n/Spanish.json
@@ -38,6 +38,14 @@
         "selectDialogue": "Seleccionar...",
         "select": "Seleccionar",
         "filter": "",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "search": "",
         "close": "",
         "couldNotLoadFromClipboard": "",

--- a/app/data/i18n/Turkish.json
+++ b/app/data/i18n/Turkish.json
@@ -28,6 +28,14 @@
         "exit": "Çık",
         "reallyExitConfirm": "Çıkmak istediğinden emin misin? Kaydedilmeyen değişikliklerin tümü yok olacak!",
         "filter": "Filtre:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "loading": "Yükleniyor…",
         "name": "İsim:",
         "nameTaken": "Bu isim zaten alınmış",

--- a/app/data/i18n/Ukranian.json
+++ b/app/data/i18n/Ukranian.json
@@ -39,6 +39,14 @@
         "zoomIn": "Приблизити",
         "zoomOut": "Віддалити",
         "filter": "Відфільтрувати:",
+        "filters": {
+            "everything": "",
+            "rooms": "",
+            "scripts": "",
+            "sounds": "",
+            "templates": "",
+            "textures": ""
+        },
         "selectDialogue": "Вибрати…",
         "search": "Пошук:",
         "close": "Закрити",

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -440,7 +440,7 @@ const launchApp = () => nwBuilder({
     mode: 'run',
     ...nwBuilderOptions,
     arch: process.arch,
-    platform: process.platform === 'win32' ? 'win' : process.platform
+    platform: process.platform === 'win32' ? 'win' : (process.platform === 'darwin' ? 'osx' : process.platform)
 })
 .catch(error => {
     showErrorBox();

--- a/src/icons/texture.svg
+++ b/src/icons/texture.svg
@@ -1,3 +1,8 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="feather">
 <path d="M3 9V19C3 20.1046 3.89543 21 5 21H19C20.1046 21 21 20.1046 21 19V9M3 9V5C3 3.89543 3.89543 3 5 3H19C20.1046 3 21 3.89543 21 5V9M3 9L8 7L12 9L16 7L21 9" stroke="currentColor"/>
+<path d="M6,8L6,21" stroke="currentColor"/>
+<path d="M9,7.5L9,21" stroke="currentColor"/>
+<path d="M12,8.5L12,21" stroke="currentColor"/>
+<path d="M15,7.5L15,21" stroke="currentColor"/>
+<path d="M18,8L18,21" stroke="currentColor"/>
 </svg>

--- a/src/riotTags/shared/asset-browser.tag
+++ b/src/riotTags/shared/asset-browser.tag
@@ -243,7 +243,7 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
             rooms: 'room',
             sounds: 'sound',
             templates: 'template',
-            scripts: ['behavior', 'script']
+            scripts: ['behavior', 'script', 'enum']
         };
 
         const resources = require('src/node_requires/resources');

--- a/src/riotTags/shared/asset-browser.tag
+++ b/src/riotTags/shared/asset-browser.tag
@@ -106,6 +106,51 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
             button.inline.square(if="{!opts.forcelayout}" onclick="{switchLayout}")
                 svg.feather
                     use(xlink:href="#{layoutToIconMap[currentLayout]}")
+            .twoLevelGroup(if="{assetTypes[0] === 'all' && !opts.customfilter}")
+                .aButtonGroup.nml
+                    button.inline.square.micro(
+                        onclick="{switchFilter('ui')}"
+                        class="{selected: filters.includes('ui') && !searchResults}"
+                        title="{vocGlob.filters.textures}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#texture")
+                    button.inline.square.micro(
+                        onclick="{switchFilter('sounds')}"
+                        class="{selected: filters.includes('sounds') && !searchResults}"
+                        title="{vocGlob.filters.sounds}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#headphones")
+                    button.inline.square.micro(
+                        onclick="{switchFilter('templates')}"
+                        class="{selected: filters.includes('templates') && !searchResults}"
+                        title="{vocGlob.filters.templates}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#template")
+                .aButtonGroup.nml
+                    button.inline.square.micro(
+                        onclick="{switchFilter('rooms')}"
+                        class="{selected: filters.includes('rooms') && !searchResults}"
+                        title="{vocGlob.filters.rooms}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#room")
+                    button.inline.square.micro(
+                        onclick="{switchFilter('scripts')}"
+                        class="{selected: filters.includes('scripts') && !searchResults}"
+                        title="{vocGlob.filters.scripts}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#code-alt")
+                    button.inline.square.micro(
+                        onclick="{switchFilter('all')}"
+                        class="{selected: filters.includes('all') && !searchResults}"
+                        title="{vocGlob.filters.everything}"
+                    )
+                        svg.sfeather
+                            use(xlink:href="#grid-random")
             button.inline.square.nogrow.nmr(onclick="{addNewFolder}")
                 svg.feather
                     use(xlink:href="#folder-plus")
@@ -192,6 +237,14 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
         this.mixin(require('src/node_requires/riotMixins/niceTime').default);
         this.sort = 'type';
         this.sortReverse = false;
+        this.filters = ['all'];
+        this.allowedTypesByFilter = {
+            ui: ['style', 'texture', 'tandem', 'font'],
+            rooms: 'room',
+            sounds: 'sound',
+            templates: 'template',
+            scripts: ['behavior', 'script']
+        };
 
         const resources = require('src/node_requires/resources');
         this.assetTypes = this.opts.assettypes ? this.opts.assettypes.split(',') : ['all'];
@@ -345,6 +398,13 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
             if (this.opts.customfilter) {
                 this.entries = this.entries
                     .filter(entry => entry.type === 'folder' || this.opts.customfilter(entry));
+            } else {
+                this.entries = this.entries
+                    .filter(entry =>
+                        entry.type === 'folder' ||
+                        this.filters[0] === 'all' ||
+                        this.filters.find(key =>
+                            this.allowedTypesByFilter[key].includes(entry.type)));
             }
             if (this.sort === 'name') {
                 if (this.opts.names) {
@@ -380,6 +440,22 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
             if (this.sortReverse) {
                 this.entries.reverse();
             }
+        };
+        this.switchFilter = which => () => {
+            document.activeElement.blur();
+            if (which === 'all') {
+                this.filters = ['all'];
+            } else if (this.filters[0] === 'all') {
+                this.filters = [which];
+            } else if (this.filters.includes(which)) {
+                this.filters.splice(this.filters.indexOf(which), 1);
+            } else {
+                this.filters.push(which);
+            }
+            if (this.filters.length === 5 || !this.filters.length) {
+                this.filters = ['all'];
+            }
+            this.updateList();
         };
         this.switchSort = sort => () => {
             if (this.sort === sort) {

--- a/src/styl/common.styl
+++ b/src/styl/common.styl
@@ -145,10 +145,23 @@ icon(icon = 'slash', color = act)
     h1 &, h2 &
         vertical-align bottom
 
+.sfeather
+    width 1rem
+    height 1rem
+    vertical-align -0.35em
+    h1 &, h2 &
+        vertical-align bottom
+
 .icon
     stroke none
     fill currentColor
 .feather
+    stroke currentColor
+    stroke-width 2
+    stroke-linecap round
+    stroke-linejoin round
+    fill none
+.sfeather
     stroke currentColor
     stroke-width 2
     stroke-linecap round

--- a/src/styl/common.styl
+++ b/src/styl/common.styl
@@ -145,12 +145,6 @@ icon(icon = 'slash', color = act)
     h1 &, h2 &
         vertical-align bottom
 
-.sfeather
-    width 1rem
-    height 1rem
-    vertical-align -0.35em
-    h1 &, h2 &
-        vertical-align bottom
 
 .icon
     stroke none
@@ -162,6 +156,9 @@ icon(icon = 'slash', color = act)
     stroke-linejoin round
     fill none
 .sfeather
+    width 1rem
+    height 1rem
+    vertical-align -0.35em
     stroke currentColor
     stroke-width 2
     stroke-linecap round

--- a/src/styl/common.styl
+++ b/src/styl/common.styl
@@ -145,7 +145,6 @@ icon(icon = 'slash', color = act)
     h1 &, h2 &
         vertical-align bottom
 
-
 .icon
     stroke none
     fill currentColor
@@ -156,8 +155,8 @@ icon(icon = 'slash', color = act)
     stroke-linejoin round
     fill none
 .sfeather
-    width 1rem
-    height 1rem
+    width 1.4rem
+    height 1.1rem
     vertical-align -0.35em
     stroke currentColor
     stroke-width 2

--- a/src/styl/inputs.styl
+++ b/src/styl/inputs.styl
@@ -111,6 +111,8 @@ input[type="reset"],
     &.square
         padding 0.7em
         line-height 1
+    &.micro
+        font-size: 0.5em;
     &.tiny
         padding 0.35rem
         line-height 1em
@@ -217,6 +219,13 @@ input[type="reset"],
             color error
         &:after
             background error
+
+.twoLevelGroup
+    display inline-flex
+    flex-direction column
+    margin-top -0.25rem
+    row-gap: 2px
+    vertical-align: top
 
 .aButtonGroup
     display inline-flex

--- a/src/styl/inputs.styl
+++ b/src/styl/inputs.styl
@@ -223,9 +223,24 @@ input[type="reset"],
 .twoLevelGroup
     display inline-flex
     flex-direction column
-    margin-top -0.25rem
-    row-gap: 2px
+    padding-right 1rem;
+    margin-top -0.375rem
     vertical-align: top
+
+.twoLevelGroup .aButtonGroup:last-child
+    margin-top -1px
+
+.twoLevelGroup .aButtonGroup:first-child button:first-child
+    border-bottom-left-radius 0
+
+.twoLevelGroup .aButtonGroup:last-child button:first-child
+    border-top-left-radius 0
+
+.twoLevelGroup .aButtonGroup:first-child button:last-child
+    border-bottom-right-radius 0
+
+.twoLevelGroup .aButtonGroup:last-child button:last-child
+    border-top-right-radius 0
 
 .aButtonGroup
     display inline-flex


### PR DESCRIPTION
A simple change for those of us who haven't embraced the folder structure yet.

This adds a small button group that lets users quickly filter by asset type. Six button are provided:

* Textures, UX and FX
* Sounds
* Templates
* Rooms
* Scripts and behaviors
* Everything

You can select multiple. If you deselect all, select all five or press the "Everything" button - it defaults to everything. If you search the filters are ignored.

Design decisions were made - it's small rather than big - possibly too small but I figure the focus should be on the other stuff. The texture icon has also been tweaked to look like wrapping paper.

![filters](https://github.com/user-attachments/assets/7994612d-fc99-463a-8901-bb8ea8e3e634)

**Ping @CosmoMyzrailGorynych**