### PR TITLE
:zap: Transparent room backgrounds

### DIFF
--- a/src/ct.release/rooms.ts
+++ b/src/ct.release/rooms.ts
@@ -1,4 +1,3 @@
-import uLib from './u';
 import backgrounds, {Background} from './backgrounds';
 import templatesLib, {BasicCopy, killRecursive} from './templates';
 import {Tilemap} from './tilemaps';
@@ -252,7 +251,7 @@ export class Room extends PIXI.Container<pixiMod.DisplayObject> {
             if (isRoot) {
                 roomsLib.current = this;
                 (pixiApp.renderer as pixiMod.Renderer).background.color =
-                    uLib.hexToPixi(this.template.backgroundColor);
+                    this.template.backgroundColor;
             }
             /*!%beforeroomoncreate%*/
             for (let i = 0, li = template.bgs.length; i < li; i++) {

--- a/src/node_requires/roomEditor/index.ts
+++ b/src/node_requires/roomEditor/index.ts
@@ -345,8 +345,7 @@ class RoomEditor extends PIXI.Application {
 
     deserialize(room: IRoom): void {
         this.simulate = room.simulate ?? true;
-        (this.renderer as PIXI.Renderer).background.color =
-            PIXI.utils.string2hex(room.backgroundColor ?? '#000000');
+        (this.renderer as PIXI.Renderer).background.color = room.backgroundColor ?? '#000000';
         // Add primary viewport
         this.primaryViewport = new Viewport(room, true, this);
         this.restrictViewport = new ViewportRestriction(this);

--- a/src/node_requires/roomEditor/previewer.ts
+++ b/src/node_requires/roomEditor/previewer.ts
@@ -68,7 +68,7 @@ export class RoomEditorPreview extends PIXI.Application {
         // Solid-fill background as set in room settings
         if (!room.isUi) {
             const background = new PIXI.Graphics();
-            background.beginFill(PIXI.utils.string2hex(room.backgroundColor || '#000000'));
+            background.beginFill(room.backgroundColor || '#000000');
             background.drawRect(0, 0, room.width, room.height);
             background.endFill();
             this.stage.addChild(background);

--- a/src/riotTags/catnip/catnip-block.tag
+++ b/src/riotTags/catnip/catnip-block.tag
@@ -252,7 +252,7 @@ catnip-block(
     )
     .aDimmer(if="{colorValue}" draggable="true" ondragstart="{preventDrag}")
         color-picker(
-            hidealpha="hidealpha"
+            hidealpha="true"
             onapply="{applyColorValue}"
             oncancel="{closeColorPicker}"
             color="{opts.block.values[colorValue]}"

--- a/src/riotTags/editors/room-editor/room-editor.tag
+++ b/src/riotTags/editors/room-editor/room-editor.tag
@@ -184,7 +184,6 @@ room-editor.aPanel.aView(data-hotkey-scope="{asset.uid}")
     context-menu(menu="{visibilityMenu}" ref="visibilityMenu" if="{pixiEditor}")
     context-menu(menu="{entitiesMenu}" ref="entitiesMenu" if="{pixiEditor}")
     script.
-        const PIXI = require('pixi.js');
         this.namespace = 'roomView';
         this.mixin(require('src/node_requires/riotMixins/voc').default);
         this.mixin(require('src/node_requires/riotMixins/discardio').default);
@@ -441,7 +440,7 @@ room-editor.aPanel.aView(data-hotkey-scope="{asset.uid}")
 
         this.changeBgColor = (e, color) => {
             this.room.backgroundColor = color;
-            this.pixiEditor.renderer.backgroundColor = PIXI.utils.string2hex(color);
+            this.pixiEditor.renderer.backgroundColor = color;
         };
 
         this.changeSimulated = () => {

--- a/src/riotTags/editors/room-editor/room-properties.tag
+++ b/src/riotTags/editors/room-editor/room-properties.tag
@@ -123,7 +123,7 @@ room-properties.npt(class="{opts.class}")
         color-input.wide(
             onchange="{changeBgColor}"
             color="{opts.room.backgroundColor || '#000000'}"
-            hidealpha="hidealpha"
+            hidealpha="{currentProject.settings.rendering.transparent ? '' : 'true'}"
         )
     extensions-editor(
         entity="{opts.room.extends}"

--- a/src/riotTags/editors/template-editor.tag
+++ b/src/riotTags/editors/template-editor.tag
@@ -125,7 +125,7 @@ mixin templateProperties
                 if="{parent.asset.selectionColor}"
                 onchange="{parent.wire('asset.selectionColor', true)}"
                 color="{parent.asset.selectionColor}"
-                hidealpha="hidealpha"
+                hidealpha="true"
             )
 
         // Scroll speed for repeating textures

--- a/src/riotTags/shared/color-picker.tag
+++ b/src/riotTags/shared/color-picker.tag
@@ -81,6 +81,9 @@ color-picker
 
         this.loadColor = color => {
             this.color = brehautColor(color);
+            if (this.color.alpha < 1 && this.opts.hidealpha) {
+                this.color = this.color.setAlpha(1);
+            }
             this.color = this.color.setValue(this.color.getValue());
             this.oldColor = brehautColor(color);
         };


### PR DESCRIPTION
This fixes https://github.com/ct-js/ct-js/issues/6

PIXI.js 7 accepts most HTML colours. As a result you can just pass through your values - `string2hex` and `hexToPixi` are no longer needed.

The bit that isn't discussed is Safari/WebKit performance is significantly impacted when using transparent canvases. Chrome's performance is still pretty good.

It's also pretty simple to support RGBA hex values - this PR doesn't do that but I wonder if it may be worthwhile eventually.

**Ping @CosmoMyzrailGorynych**
