### PR TITLE
:bug: Placed copies use template's opacity

### DIFF
--- a/src/node_requires/roomEditor/interactions/copies/placeCopy.ts
+++ b/src/node_requires/roomEditor/interactions/copies/placeCopy.ts
@@ -37,7 +37,7 @@ const createCopy = (
         y: 1
     },
     uid: template.uid,
-    opacity: 1,
+    opacity: (template.extends.alpha as number) || 1,
     rotation: 0,
     tint: 0xffffff
 }, editor, ghost);


### PR DESCRIPTION
A simple fix for #10 which was bugging me as well.

When placed a copy now uses the template's opacity setting. This means that you won't be able to retrospectively adjust the opacity of all placed copies but I think that's okay.
 
The use of the `||` also means you can't set a copy's opacity to zero - but I feel that there really isn't any reason to allow that. You can always set visible to false or, if you're ramping up you copy's opacity, just set the value to zero after placement or set the alpha programmatically in `onCreate`.

**Ping @CosmoMyzrailGorynych**