### PR TITLE
:bug: Fixes unexpected reversion to default text of text copies

### DIFF
--- a/src/node_requires/roomEditor/entityClasses/Copy.ts
+++ b/src/node_requires/roomEditor/entityClasses/Copy.ts
@@ -192,10 +192,19 @@ class Copy extends PIXI.Container {
             customProperties: deepCopy ?
                 JSON.parse(JSON.stringify(this.copyCustomProps)) :
                 this.copyCustomProps,
+            customText: this.customTextSettings?.customText,
+            customSize: this.customTextSettings?.fontSize,
+            customWordWrap: this.customTextSettings?.wordWrapWidth,
             bindings: {
                 ...this.bindings
             }
         };
+        if (this.customTextSettings?.anchor) {
+            copy.customAnchor = {
+                x: this.customTextSettings?.anchor.x,
+                y: this.customTextSettings?.anchor.y
+            };
+        }
         if (this.align) {
             copy.align = this.align;
         }


### PR DESCRIPTION
A simple fix for #71 - this may not be the best fix though. I have a feeling that we were using `customProperties` for this stuff, but text being the most urgent was implemented first as something different.

The issue is 100% reproducible and from my testing this looks like a viable fix - so I'd merge it unless you have a better solution.

I'm running into the `no-undefined` lint rule a bit and wondering if we want to keep it around long-term. That said, there's always been a workaround so far.

**Ping @CosmoMyzrailGorynych**