### PR TITLE
:zap: Formatted recent projects list

### DIFF
--- a/src/riotTags/main-menu/main-menu-latest-projects.tag
+++ b/src/riotTags/main-menu/main-menu-latest-projects.tag
@@ -1,12 +1,14 @@
 main-menu-latest-projects
     h1 {voc.recentProjects}
-    ul.aMenu
+    ul.aMenu.recents
         li(each="{project in latestProjects}" title="{project}" onclick="{() => loadLatestProject(project)}")
-            span {project}
+            b {this.basename(project)}
+            br
+            small {project}
     script.
         this.namespace = 'mainMenu.latestProjects';
         this.mixin(require('src/node_requires/riotMixins/voc').default);
-
+        this.basename = (path) => path.match(/[/\\]([^/.]+)(\.[A-Za-z0-9]+)?$/)[1];
         this.refreshLatestProjects = function refreshLatestProjects() {
             if (('lastProjects' in localStorage) &&
                 (localStorage.lastProjects !== '')) {

--- a/src/styl/tags/main-menu/main-menu.styl
+++ b/src/styl/tags/main-menu/main-menu.styl
@@ -18,3 +18,13 @@ main-menu
     .&-aSection, .&-aDoubleSection, .&-aTripleSection, .&-aQuadrupleSection
         & > h1:first-child
             margin 0 0 1rem 0.65rem
+    ul.aMenu.recents
+        padding 8px auto
+        line-height 23px
+    ul.aMenu.recents small
+        opacity 0.8
+    ul.aMenu.recents li
+        padding-top: 0.4em;
+        padding-bottom: 0.4em;
+    ul.aMenu.recents li:first-child
+        padding-top: 0.2em;


### PR DESCRIPTION
Simple change that adds formatting to the recent projects list to make project selection a little easier, so not every project is your very long home directory name. The new look is:

<img width="522" alt="new-look" src="https://github.com/user-attachments/assets/21238dbd-f2ad-400c-8560-90d9b8c48330" />

Hovering still looks the same.

**Ping @CosmoMyzrailGorynych**
