### PR TITLE
:bug: Fix sound variant continuing after deletion.

### DIFF
--- a/src/riotTags/editors/sound-editor/sound-editor.tag
+++ b/src/riotTags/editors/sound-editor/sound-editor.tag
@@ -20,7 +20,7 @@ sound-editor.aView.pad.flexfix(onclick="{tryClose}")
                         .aSpacer.nogrow
                         button.square.inline.alignmiddle.nogrow.large(onclick="{playVariant(variant)}" title="{vocGlob.play}")
                             svg.feather
-                                use(xlink:href="#{(currentSoundPlaying && currentVariant === variant) ? 'pause' : 'play'}")
+                                use(xlink:href="#{(currentSoundPlaying && currentVariant && currentVariant.uid === variant.uid) ? 'pause' : 'play'}")
                         // button.square.inline.alignmiddle.nogrow(title="{vocGlob.reimport}")
                         //     svg.feather
                         //         use(xlink:href="#refresh-ccw")
@@ -185,6 +185,14 @@ sound-editor.aView.pad.flexfix(onclick="{tryClose}")
 
         this.getPreview = (variant, long) => SoundPreviewer.get(this.asset, false, variant.uid, long);
 
+        this.stopCurrentSound = () => {
+            if (this.currentSoundPlaying) {
+                this.currentSoundPlaying.stop();
+                this.currentSoundPlaying = null;
+                this.currentVariant = null;
+            }
+        };
+
         // TODO: #466
         // remove the old variant from pixi.sound first
         /*
@@ -193,6 +201,9 @@ sound-editor.aView.pad.flexfix(onclick="{tryClose}")
         */
 
         this.deleteVariant = variant => () => {
+            if (this.currentVariant && this.currentVariant.uid === variant.uid) {
+                this.stopCurrentSound();
+            }
             const newVariants = this.asset.variants.filter(el => el.uid !== variant.uid);
             this.asset.variants = newVariants;
         };
@@ -210,19 +221,18 @@ sound-editor.aView.pad.flexfix(onclick="{tryClose}")
             this.update();
         };
         this.playVariant = (variant, testing) => () => {
-            // Stop any previous sound
+            // Clicked on the same variant that was played: toggle stop playback.
+            if (this.currentVariant && this.currentVariant.uid === variant.uid) {
+                this.stopCurrentSound();
+                return;
+            }
+
+            // Stop any previous sound before playing new one
             if (this.currentSoundPlaying) {
-                this.currentSoundPlaying.stop();
-                this.currentSoundPlaying = null;
+                this.stopCurrentSound();
                 if (testing) {
-                    this.currentVariant = null;
                     return;
                 }
-            }
-            // Clicked on the save variant that was played: just stop playback.
-            if (this.currentVariant === variant) {
-                this.currentVariant = null;
-                return;
             }
             this.currentVariant = variant;
             this.currentSoundPlaying = (testing ? playVariant : playWithoutEffects)(this.asset, variant, {
@@ -268,9 +278,7 @@ sound-editor.aView.pad.flexfix(onclick="{tryClose}")
 
         this.saveAsset = () => {
             this.writeChanges();
-            if (this.currentSoundPlaying) {
-                this.currentSoundPlaying.stop();
-            }
+            this.stopCurrentSound();
             return true;
         };
         this.saveAndClose = () => {


### PR DESCRIPTION
Closes #15.

`gulp build` and `gulp lint` ran without issues related to this change.

Built locally and tested the following audio behaviors:

- Delete playing variant
- Toggle play/pause
- Switch between variants (play B stops play A)
- Delete non-playing variant (delete B does not stop A)
- Save while playing stops variant

**Changes proposed in this pull request:**

- Created `stopCurrentSound()` helper function that stops the audio instance and clears state variables to eliminate code duplication across `playVariant`, `saveAsset`, and `deleteVariant`.
- Fixed deleteVariant() to stop playing sounds by checking if the deleted variant's UID matches the currently playing variant before deletion.
- Replaced reference equality (===) with UID comparison across all variant checks because structuredClone() in the discardio mixin breaks object references, ensuring reliable variant matching in the template UI and both functions. Found this since not checking with UID was not properly fixing this.

**Help wanted:** (optional, e.g. a request for GUI revamp)

- `gulp lint` is noisy and has a lot of existing warnings/errors:

```
[00:01:00] Starting 'lintTags'...
[00:01:05] 
/Users/edgarsanmartin/Documents/OS/ctjs/ct-js/src/riotTags/debugger/debugger-screen-multiwindow.pug
  43:84  error  Missing semicolon  semi

/Users/edgarsanmartin/Documents/OS/ctjs/ct-js/src/riotTags/debugger/debugger-screen-split.pug
  66:84  error  Missing semicolon  semi

/Users/edgarsanmartin/Documents/OS/ctjs/ct-js/src/riotTags/editors/sound-editor/sound-editor.pug
  196:9  warning  Unexpected 'todo' comment: 'TODO: #466'  no-warning-comments

/Users/edgarsanmartin/Documents/OS/ctjs/ct-js/src/riotTags/shared/asset-browser.pug
  513:17  warning  Unexpected 'todo' comment: 'TODO: folder selection on shift and ctrl...'  no-warning-comments

/Users/edgarsanmartin/Documents/OS/ctjs/ct-js/src/riotTags/shared/extensions-editor.pug
  274:17  warning  Unexpected 'todo' comment: 'TODO: move this logic into...'  no-warning-comments

✖ 5 problems (2 errors, 3 warnings)
  2 errors and 0 warnings potentially fixable - see https://www.npmjs.com/package/gulp-eslint-new/v/1.9.1#autofix
```

We should silence most of these since they are related to `TODO` comments, though there are lots of warnings in the other lints across the codebase. But we should deff fix the lint errors.

**Ping @CosmoMyzrailGorynych**
