### PR TITLE
✨ Add anchor and pivot blocks to Catnip.

### DIFF
--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -346,6 +346,12 @@
             "set skew": "Set skew to",
             "skew x": "skew by x",
             "skew y": "skew by y",
+            "set anchor": "Set anchor to",
+            "anchor x": "anchor by x",
+            "anchor y": "anchor by y",
+            "set pivot": "Set pivot to",
+            "pivot x": "pivot by x",
+            "pivot y": "pivot by y",
             "set alpha": "Set opacity to",
             "set visible": "Set visibility to",
             "scale x": "scale by x",
@@ -669,7 +675,9 @@
         },
         "blockDocumentation": {
             "serialize object": "This block serializes an object into a string that can be later safely saved or transferred. This method does not support dates, functions, and structures that form cyclic references. Objects serialized with this block should be deserialized with the \"Deserialize object\" block.",
-            "constant string": "You can use this block to force creating a string: for example, when you want to write a number in a string or convert \\n to a linebreak when putting this value into wildcard slots."
+            "constant string": "You can use this block to force creating a string: for example, when you want to write a number in a string or convert \\n to a linebreak when putting this value into wildcard slots.",
+            "set anchor": "Sets the anchor point using normalized coordinates (0.0 to 1.0). The anchor determines where the copy rotates and scales from. Common values: (0, 0) = top-left, (0.5, 0.5) = center, (1, 1) = bottom-right. Works on textured copies like Animated Sprites.",
+            "set pivot": "Sets the pivot point using pixel coordinates. Like anchor, but uses absolute pixels instead of percentages. Advanced usage — use anchor for most cases."
         }
     },
     "colorPicker": {

--- a/src/node_requires/catnip/stdLib/appearance.ts
+++ b/src/node_requires/catnip/stdLib/appearance.ts
@@ -94,6 +94,46 @@ const blocks: (IBlockCommandDeclaration | IBlockComputedDeclaration)[] = [{
         required: true
     }]
 }, {
+    name: 'Set anchor',
+    type: 'command',
+    code: 'set anchor',
+    icon: 'droplet',
+    jsTemplate: (vals) => `this.anchor.set(${vals.x}, ${vals.y});`,
+    lib: 'core.appearance',
+    i18nKey: 'set anchor',
+    documentationI18nKey: 'set anchor',
+    pieces: [{
+        type: 'argument',
+        key: 'x',
+        typeHint: 'number',
+        required: true
+    }, {
+        type: 'argument',
+        key: 'y',
+        typeHint: 'number',
+        required: true
+    }]
+}, {
+    name: 'Set pivot',
+    type: 'command',
+    code: 'set pivot',
+    icon: 'droplet',
+    jsTemplate: (vals) => `this.pivot.set(${vals.x}, ${vals.y});`,
+    lib: 'core.appearance',
+    i18nKey: 'set pivot',
+    documentationI18nKey: 'set pivot',
+    pieces: [{
+        type: 'argument',
+        key: 'x',
+        typeHint: 'number',
+        required: true
+    }, {
+        type: 'argument',
+        key: 'y',
+        typeHint: 'number',
+        required: true
+    }]
+}, {
     name: 'Set texture angle',
     type: 'command',
     code: 'set angle',
@@ -331,6 +371,46 @@ const blocks: (IBlockCommandDeclaration | IBlockComputedDeclaration)[] = [{
     jsTemplate: () => 'this.skew.y',
     lib: 'core.appearance',
     i18nKey: 'skew y',
+    pieces: [],
+    typeHint: 'number'
+}, {
+    name: 'get anchor by x',
+    type: 'computed',
+    code: 'get anchor x',
+    icon: 'droplet',
+    jsTemplate: () => 'this.anchor.x',
+    lib: 'core.appearance',
+    i18nKey: 'anchor x',
+    pieces: [],
+    typeHint: 'number'
+}, {
+    name: 'get anchor by y',
+    type: 'computed',
+    code: 'get anchor y',
+    icon: 'droplet',
+    jsTemplate: () => 'this.anchor.y',
+    lib: 'core.appearance',
+    i18nKey: 'anchor y',
+    pieces: [],
+    typeHint: 'number'
+}, {
+    name: 'get pivot by x',
+    type: 'computed',
+    code: 'get pivot x',
+    icon: 'droplet',
+    jsTemplate: () => 'this.pivot.x',
+    lib: 'core.appearance',
+    i18nKey: 'pivot x',
+    pieces: [],
+    typeHint: 'number'
+}, {
+    name: 'get pivot by y',
+    type: 'computed',
+    code: 'get pivot y',
+    icon: 'droplet',
+    jsTemplate: () => 'this.pivot.y',
+    lib: 'core.appearance',
+    i18nKey: 'pivot y',
     pieces: [],
     typeHint: 'number'
 }, {


### PR DESCRIPTION
Closes #45 

**Changes proposed in this pull request:**

- Add `pivot` catnip blocks with getter and setters to Appearance panel
- Add `anchor` catnip blocks with getter and setters to Appearance panel
- Properly document blocks in respective i18n descriptions at English.json

Image previews:

<img width="446" height="141" alt="Screen Shot 2025-12-21 at 5 51 55 PM" src="https://github.com/user-attachments/assets/077f90db-11b5-4ccc-bf3e-24f8ee9fcb6a" />

<img width="414" height="158" alt="Screen Shot 2025-12-21 at 5 52 52 PM" src="https://github.com/user-attachments/assets/8527b07d-cd42-4349-88f6-26cdc1413246" />

**Ping @CosmoMyzrailGorynych**
