### PR TITLE
fix(app): remove product_string from NW.js manifest

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,6 @@
 {
   "main": "index.html",
   "name": "ctjs",
-  "product_string": "ct.js",
   "description": "ct.js — a free 2D game engine",
   "version": "5.3.0",
   "homepage": "https://ctjs.rocks/",


### PR DESCRIPTION
Closes #79 

**Changes proposed in this pull request:**

- Remove product_string from NW.js manifest since nw-builder automatically renames all MacOS Helper apps and sets this value. This causes issues during mode=run where the product_string=app_name but the Helper Apps are still named NW.js where the application fails to launch.

https://github.com/nwutils/nw-builder/blob/5c35daaebfb391ba1f9aac6e464faa0fb238ad71/src/bld.js#L136

**Ping @CosmoMyzrailGorynych**
